### PR TITLE
chore(release): KeyWatch v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-[Unreleased]
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0] - 2025-02-16
 
 - Initial Release
   - Support reading file, directory with verbose output in console

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "key-watch"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2021"
 authors = ["Pa1Nark <pa1nark@pixincreate.dev>"]
 license = "GPL-3.0"


### PR DESCRIPTION
## [1.0.0] - 2025-02-16

- Initial Release
  - Support reading file, directory with verbose output in console
  - Output results to a file
  - Support various types of keys / secrets / tokens and etc.,