### PR TITLE
release(KeyWatch): version 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [2.0.0] - 2026-08-02
+
 ### Breaking Changes
 
 - Public Rust APIs now return module-local typed errors instead of `String` or boxed errors. This affects CLI validation, baseline, configuration, detector initialization, scanner, hook, and `run_cli()` return types and requires a major-version release.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,7 +305,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "key-watch"
-version = "1.1.0"
+version = "2.0.0"
 dependencies = [
  "clap",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "key-watch"
-version = "1.1.0"
+version = "2.0.0"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Pa1Nark <pa1nark@pixincreate.dev>"]

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
   version:
     description: 'Exact KeyWatch release version to install'
     required: false
-    default: '1.1.0'
+    default: '2.0.0'
   paths:
     description: 'Paths to scan (space-separated, supports globs)'
     required: false

--- a/scripts/action_validation/release_script_scenario.py
+++ b/scripts/action_validation/release_script_scenario.py
@@ -92,7 +92,14 @@ def run_release_scenario(root: Path) -> None:
         cargo_calls = cargo_capture.read_text(encoding="utf-8")
         require("version = \"2.0.0\"" in cargo, "release must update Cargo.toml")
         require("version = \"2.0.0\"" in lock, "release must update Cargo.lock")
-        require("## [2.0.0] -" in changelog, "release must promote the changelog")
+        require(
+            re.search(
+                r"(?m)^## \[Unreleased\]\n\n## \[2\.0\.0\] - \d{4}-\d{2}-\d{2}$",
+                changelog,
+            )
+            is not None,
+            "release must keep Unreleased and the release heading on separate lines",
+        )
         require(
             re.search(r"(?m)^    default: '2\.0\.0'$", action) is not None,
             "release must update the Action version",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -102,11 +102,16 @@ update_version_files() {
         Cargo.toml
     rm Cargo.toml.bak
 
-    sed -i.bak \
-        -e "s/^## \[Unreleased\]$/## [Unreleased]\
-\
-## [$VERSION] - $DATE/" \
-        CHANGELOG.md && rm CHANGELOG.md.bak
+    local changelog_tmp
+    changelog_tmp=$(mktemp "${TMPDIR:-/tmp}/keywatch-changelog.XXXXXX")
+    awk -v version="$VERSION" -v release_date="$DATE" '
+        { print }
+        $0 == "## [Unreleased]" {
+            print ""
+            print "## [" version "] - " release_date
+        }
+    ' CHANGELOG.md > "$changelog_tmp"
+    mv "$changelog_tmp" CHANGELOG.md
 
     sed -i.bak \
         -e "/^  version:$/,/^  paths:$/ s/^    default: .*/    default: '$VERSION'/" \


### PR DESCRIPTION
## Summary
- Bump versions to 2.0.0
- Update CHANGELOG.md

## Next steps
- Merge this PR
- Run ./scripts/release.sh create_tag 2.0.0 [--publish-crates]