### PR TITLE
fix: ignore Python bytecode during release validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@
 # Rust builds
 /target
 
+# Python bytecode
+__pycache__/
+*.py[cod]
+
 # Environment files
 .env
 .envrc

--- a/scripts/action_validation/validate.py
+++ b/scripts/action_validation/validate.py
@@ -73,8 +73,12 @@ def validate_workflows() -> None:
 def main() -> int:
     text = ACTION.read_text(encoding="utf-8")
     cargo_toml = (ROOT / "Cargo.toml").read_text(encoding="utf-8")
+    gitignore = (ROOT / ".gitignore").read_text(encoding="utf-8")
     blocks = run_blocks(text)
     shell = "\n".join(blocks)
+
+    require("__pycache__/" in gitignore, "Python bytecode caches must be ignored")
+    require("*.py[cod]" in gitignore, "Python bytecode files must be ignored")
 
     cargo_version = re.search(r'^version = "([^"]+)"$', cargo_toml, re.MULTILINE)
     action_version = re.search(


### PR DESCRIPTION
## Summary

- ignore Python bytecode caches generated by the Action validation scripts
- require the bytecode ignore rules in the distribution validator to prevent regression

## Root cause

The v2.0.0 GitHub Release preflight ran the Python validator, which imported scenario modules and generated untracked `__pycache__/*.pyc` files. The subsequent strict `cargo package --locked` check rejected the dirty checkout.

## Verification

- regression reproduced before the fix: `ERROR: Python bytecode caches must be ignored`
- `python3 scripts/action_validation/validate.py`
- `python3 -m py_compile scripts/action_validation/*.py`
- `cargo package --locked`
- `git diff --check`
- Oracle release-safety audit: PASS