### PR TITLE
release(KeyWatch): version 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ## [2.0.1] - 2026-08-02
 
+### Fixed
+
+- GitHub Release asset publishing no longer fails when Action validation generates Python bytecode caches
+
 ## [2.0.0] - 2026-08-02
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [2.0.1] - 2026-08-02
+
 ## [2.0.0] - 2026-08-02
 
 ### Breaking Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,7 +305,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "key-watch"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "clap",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "key-watch"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Pa1Nark <pa1nark@pixincreate.dev>"]

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
   version:
     description: 'Exact KeyWatch release version to install'
     required: false
-    default: '2.0.0'
+    default: '2.0.1'
   paths:
     description: 'Paths to scan (space-separated, supports globs)'
     required: false


### PR DESCRIPTION
## Summary
- Bump versions to 2.0.1
- Update CHANGELOG.md

## Next steps
- Merge this PR
- Run ./scripts/release.sh create_tag 2.0.1 [--publish-crates]