### PR TITLE
fix: encode baseline hashes without LowerHex formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,6 +282,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,6 +316,7 @@ dependencies = [
  "clap",
  "dirs",
  "glob",
+ "hex",
  "rayon",
  "regex",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ glob = "0.3.3"
 dirs = "6.0"
 rayon = "1"
 sha2 = "0.10"
+hex = "0.4"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -24,7 +24,13 @@ fn hash_content(content: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(HASH_DOMAIN_SEPARATOR.as_bytes());
     hasher.update(content.as_bytes());
-    format!("{:x}", hasher.finalize())
+    // Encode bytes manually: sha2 0.11 switched `finalize()` from GenericArray to
+    // hybrid_array::Array, which no longer implements LowerHex for `{:x}`.
+    hasher
+        .finalize()
+        .iter()
+        .map(|byte| format!("{:02x}", byte))
+        .collect()
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -24,13 +24,7 @@ fn hash_content(content: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(HASH_DOMAIN_SEPARATOR.as_bytes());
     hasher.update(content.as_bytes());
-    // Encode bytes manually: sha2 0.11 switched `finalize()` from GenericArray to
-    // hybrid_array::Array, which no longer implements LowerHex for `{:x}`.
-    hasher
-        .finalize()
-        .iter()
-        .map(|byte| format!("{:02x}", byte))
-        .collect()
+    hex::encode(hasher.finalize())
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]


### PR DESCRIPTION
## What

sha2 0.11.0 changes `hasher.finalize()` to return `hybrid_array::Array` instead of `GenericArray`, which no longer implements `LowerHex` for `{:x}` formatting. `src/baseline.rs:27` used `format!("{:x}", hasher.finalize())`, breaking compilation (E0277) on sha2 0.11.

## Fix

Use `hex::encode` on the digest. Works on both sha2 0.10 (GenericArray) and 0.11 (hybrid_array::Array) since both implement `AsRef<[u8]>`.

## Verification

- `cargo test` with sha2 0.10.9 + hex 0.4.3: all suites pass (147 tests)
- `cargo test` after temporarily bumping to sha2 0.11.0: all suites pass (E0277 gone); `cargo clippy` clean
- Output identical to `{:x}` (existing `hash_content_uses_expected_lowercase_hex` test unchanged and passing)

Unblocks dependabot PR #80 (sha2 0.10.9 → 0.11.0).